### PR TITLE
Getting Started Redirects

### DIFF
--- a/config/rewrites.d/rewrites.json
+++ b/config/rewrites.d/rewrites.json
@@ -129,6 +129,12 @@
           "to": "/docs/getting-started/create-swarm-cluster-with-cli/",
           "rewrite": false,
           "status": 301
+        },
+        {
+          "from": "\\/docs\\/tutorials\\/docker-version-manager\\/?",
+          "to": "/docs/reference/docker-version-manager/",
+          "rewrite": false,
+          "status": 301
         }
     ]
 }

--- a/config/rewrites.d/rewrites.json
+++ b/config/rewrites.d/rewrites.json
@@ -117,6 +117,18 @@
           "to": "/docs/reference/glossary/",
           "rewrite": false,
           "status": 301
+        },
+        {
+          "from": "\\/docs\\/getting-started\\/getting-started-on-carina\\/?",
+          "to": "/docs/getting-started/create-swarm-cluster/",
+          "rewrite": false,
+          "status": 301
+        },
+        {
+          "from": "\\/docs\\/getting-started\\/getting-started-carina-cli\\/?",
+          "to": "/docs/getting-started/create-swarm-cluster-with-cli/",
+          "rewrite": false,
+          "status": 301
         }
     ]
 }


### PR DESCRIPTION
**Do not merge until the new docs go live**

* The getting started guides have been split into multiple guides: one for kubernetes and another for swarm. Redirect old generic "getting started" links to the swarm guides.
* The dvm doc isn't a tutorial and has been moved to the references section, next to the new carina cli doc.