### PR TITLE
Add rewrite from /betadocs to a staging build preview

### DIFF
--- a/config/rewrites.d/rewrites.json
+++ b/config/rewrites.d/rewrites.json
@@ -117,6 +117,13 @@
           "to": "/docs/reference/glossary/",
           "rewrite": false,
           "status": 301
+        },
+        {
+          "from": "^\\/betadocs\\/(.?)$",
+          "to": "/getcarina.com/build-38da3ce156/$1",
+          "toHostname": "staging.developer.rackspace.com",
+          "rewrite": true,
+          "status": 200
         }
     ]
 }


### PR DESCRIPTION
@smashwilson What I would like to do is give us a way to **rewrite** (not redirect)

https://getcarina.com/betadocs/docs/getting-started/create-swarm-cluster/

to 

https://staging.developer.rackspace.com/getcarina.com/build-38da3ce156/docs/getting-started/create-swarm-cluster/

This will give us a way to link beta testers to something other than a transient build preview, which keeps changing. Each time we want to update the contents of beta docs, we just update the control repo with the latest preview hash.